### PR TITLE
Trip Thumbnails Automated by Google Places API

### DIFF
--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -1,8 +1,4 @@
-// data
-export * from './data/data.service';
-
-// guard functions
-// export * from './guards/checkDirtyState'
+export * from './navigation/navigation.service';
 
 // models
 export * from './models/trip.model';

--- a/src/app/shared/navigation/navigation.service.spec.ts
+++ b/src/app/shared/navigation/navigation.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { NavigationService } from './navigation.service';
+
+describe('NavigationService', () => {
+  let service: NavigationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavigationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/navigation/navigation.service.ts
+++ b/src/app/shared/navigation/navigation.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NavigationService {
+
+  constructor(private ngZone: NgZone, private router: Router) { }
+
+  /*
+    Using this to replace routerLink where necessary as I was getting Angular Zone related/delayed loading warnings:
+    Console -> "Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?"
+  */
+  public navigate(subpaths: any[]): void {
+    // needed in order to trigger appropriate change detection when user wants to change navigation
+    // became necessary after implementing "getTripImgUrl()" in TripService in relation with Trip Resolvers
+    this.ngZone.run(() => this.router.navigate(subpaths)).then();
+  }
+}

--- a/src/app/shared/pipes/byEarliestDateFirst.pipe.ts
+++ b/src/app/shared/pipes/byEarliestDateFirst.pipe.ts
@@ -1,14 +1,15 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { map, Observable } from 'rxjs';
 import { Trip } from '../models/trip.model';
 
 @Pipe({
   name: 'byEarliestDate',
 })
 export class EarliestDateFirstPipe implements PipeTransform {
-  transform(values: Trip[]): Trip[] {
-    return values.sort(
+  transform(values: Observable<Trip[]>): Observable<Trip[]> {
+    return values.pipe(map(trips => trips.sort(
       (a: Trip, b: Trip) =>
         new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
-    );
+    )));
   }
 }

--- a/src/app/shared/pipes/byLatestDateFirst.pipe.ts
+++ b/src/app/shared/pipes/byLatestDateFirst.pipe.ts
@@ -1,14 +1,15 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { map, Observable } from 'rxjs';
 import { Trip } from 'src/app/shared/models/trip.model';
 
 @Pipe({
   name: 'byLatestDate',
 })
 export class LatestDateFirstPipe implements PipeTransform {
-  transform(values: Trip[]): Trip[] {
-    return values.sort(
+  transform(values: Observable<Trip[]>): Observable<Trip[]> {
+    return values.pipe(map(trips => trips.sort(
       (a: Trip, b: Trip) =>
         new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
-    );
+    )));
   }
 }

--- a/src/app/travel-app.component.html
+++ b/src/app/travel-app.component.html
@@ -1,3 +1,4 @@
 <app-nav-bar *ngIf="this.router.url!=='/user/login'
   && this.router.url!=='/user/new-account'" navigation></app-nav-bar>
 <router-outlet></router-outlet>
+<div id="empty"></div>

--- a/src/app/trip-page/trip-overview/trip-overview.component.html
+++ b/src/app/trip-page/trip-overview/trip-overview.component.html
@@ -79,7 +79,7 @@
 
       <!-- empty to do list: to do button -->
       <div *ngIf="trip?.toDo?.length === 0" class="flex-center empty-to-do">
-        <button class="btn btn-primary to-do-btn font700" [routerLink]="['../todo']">Start Tracking Your Tasks</button>
+        <button class="btn btn-primary to-do-btn font700" (click)="nav.navigate(['../todo'])">Start Tracking Your Tasks</button>
       </div>
     </div>
 

--- a/src/app/trip-page/trip-overview/trip-overview.component.ts
+++ b/src/app/trip-page/trip-overview/trip-overview.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { NavigationService } from 'src/app/shared';
 import { membersListProps } from '..';
 import { Trip } from '../../shared/models/trip.model';
 import { calendarDateProps } from '../calendar-date/calendar-date.component';
@@ -24,7 +25,8 @@ export class TripOverviewComponent implements OnInit {
 
   constructor(
     private tripDataService: TripDataService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    public nav: NavigationService
   ) {}
 
   ngOnInit() {

--- a/src/app/trip-page/trip-sidebar-option.component.ts/trip-sidebar-option.component.html
+++ b/src/app/trip-page/trip-sidebar-option.component.ts/trip-sidebar-option.component.html
@@ -1,4 +1,4 @@
-<div class="sidebar-option" [routerLink]="[this.properties.subpath]" routerLinkActive="option-active"
+<div class="sidebar-option" (click)="nav.navigate([this.properties.subpath])" routerLinkActive="option-active"
   #rla="routerLinkActive">
 
   <!-- sidebar option icon -->

--- a/src/app/trip-page/trip-sidebar-option.component.ts/trip-sidebar-option.component.ts
+++ b/src/app/trip-page/trip-sidebar-option.component.ts/trip-sidebar-option.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationService } from 'src/app/shared';
 
 @Component({
   selector: 'app-trip-sidebar-option',
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 export class TripSidebarOptionComponent {
   @Input() properties!: Properties;
 
-  constructor(public router: Router) {}
+  constructor(public nav: NavigationService) {}
 }
 
 type Properties = {

--- a/src/app/trip-page/trip-sidebar/trip-sidebar.component.ts
+++ b/src/app/trip-page/trip-sidebar/trip-sidebar.component.ts
@@ -11,19 +11,19 @@ export class TripSidebarComponent implements OnInit {
   trip?: Trip;
   overview = {
     name: 'Overview',
-    subpath: 'overview',
+    subpath: '404',
     icon: 'bi bi-briefcase',
     activeIcon: 'bi bi-briefcase-fill',
   };
   toDo = {
     name: 'To Do',
-    subpath: 'todo',
+    subpath: '404',
     icon: 'bi bi-clipboard2-check',
     activeIcon: 'bi bi-clipboard2-check-fill',
   };
   edit = {
     name: 'Edit Trip',
-    subpath: 'edit',
+    subpath: '404',
     icon: 'bi bi-pencil-square',
     activeIcon: 'bi bi-pencil-square',
   };
@@ -34,5 +34,9 @@ export class TripSidebarComponent implements OnInit {
     this.route.data.forEach((data) => {
       this.trip = data['trip'];
     });
+
+    this.overview.subpath = `trips/${this.trip?.id}/overview`;
+    this.toDo.subpath = `trips/${this.trip?.id}/todo`;
+    this.edit.subpath = `trips/${this.trip?.id}/edit`;
   }
 }

--- a/src/app/trip-page/trip-todo/trip-todo.component.ts
+++ b/src/app/trip-page/trip-todo/trip-todo.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { take } from 'rxjs';
 import { Trip } from 'src/app/shared';
 import { ToDo } from 'src/app/shared/models/toDo.model';
+import { NavigationService } from 'src/app/shared';
 import { TripService } from 'src/app/trips';
 
 @Component({
@@ -15,10 +16,10 @@ export class TripToDoComponent implements OnInit {
   toDoForm!: FormGroup;
 
   constructor(
-    private router: Router,
     private route: ActivatedRoute,
     private fb: FormBuilder,
-    private tripService: TripService
+    private tripService: TripService,
+    public nav: NavigationService
   ) {}
 
   ngOnInit() {
@@ -101,10 +102,7 @@ export class TripToDoComponent implements OnInit {
       .updateTrip(this.trip)
       .pipe(take(1))
       .subscribe(() => {
-        // deactivate route guard
-        // this.toDoComponent.isDirty = false;
-        //reroute to newly created trip
-        this.router.navigate([`/trips/${this.trip.id}`]);
+        this.nav.navigate([`/trips/${this.trip.id}`]);
       });
   }
 
@@ -131,11 +129,10 @@ export class TripToDoComponent implements OnInit {
 
   onSubmit() {
     this.trip.toDo = this.fitFormValuesToModel();
-    console.log(this.trip.toDo);
     this.updateTrip();
   }
 
   cancel() {
-    this.router.navigate([`/trips/${this.trip?.id}`]);
+    this.nav.navigate([`/trips/${this.trip?.id}`]);
   }
 }

--- a/src/app/trips/shared/trip.service.ts
+++ b/src/app/trips/shared/trip.service.ts
@@ -108,33 +108,36 @@ export class TripService {
     );
   }
 
-  sortByTitle(trips: Trip[]): Trip[] {
-    // console.log("Trips sorted alphabetically by title");
-    return (trips = trips.sort((a: Trip, b: Trip) =>
-      a.title.localeCompare(b.title)
-    ));
+  sortByTitle(trips: Observable<Trip[]>): Observable<Trip[]> {
+    return trips.pipe(
+      map((trips) =>
+        trips.sort((a: Trip, b: Trip) => a.title.localeCompare(b.title))
+      )
+    );
   }
 
-  sortByEarliestDate(trips: Trip[]): Trip[] {
-    // default for PREVIOUS dates
-    // console.log("Trips sorted by earliest date");
-
+  sortByEarliestDate(trips: Observable<Trip[]>): Observable<Trip[]> {
     // sorting by EARLIEST DATE: sorts dates oldest-newest
-    return (trips = trips.sort(
-      (a: Trip, b: Trip) =>
-        new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
-    ));
+    return trips.pipe(
+      map((trips) =>
+        trips.sort(
+          (a: Trip, b: Trip) =>
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+        )
+      )
+    );
   }
 
-  sortByLatestDate(trips: Trip[]): Trip[] {
-    // default for UPCOMING dates
-    // console.log("Trips sorted by latest date");
-
+  sortByLatestDate(trips: Observable<Trip[]>): Observable<Trip[]> {
     // sorting by LATEST DATE: sorts dates newest-oldest
-    return (trips = trips.sort(
-      (a: Trip, b: Trip) =>
-        new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
-    ));
+    return trips.pipe(
+      map((trips) =>
+        trips.sort(
+          (a: Trip, b: Trip) =>
+            new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+        )
+      )
+    );
   }
 
   // Unfortunately I can't store the requested Google photos to my DB because they are owned by Google Users (against Google's Terms of Service)

--- a/src/app/trips/shared/trip.service.ts
+++ b/src/app/trips/shared/trip.service.ts
@@ -153,7 +153,7 @@ export class TripService {
           // if google has any photos for the given placeId
           if (placeResult.photos.length !== 0) {
             imgUrl = placeResult.photos[1].getUrl({
-              maxWidth: 1280, // at least set one or the other - mandatory
+              maxWidth: 1920, // at least set one or the other - mandatory
               maxHeight: undefined,
             });
           }

--- a/src/app/trips/trip-forms/new-trip/new-trip.component.ts
+++ b/src/app/trips/trip-forms/new-trip/new-trip.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Trip } from 'src/app/shared';
+import { NavigationService } from 'src/app/shared';
 
 // this function will be probably used in other components down the road (e.g. edit-profile)
 // What seems like the most 'fitting' spot to put this?
@@ -23,6 +24,8 @@ export class NewTripComponent implements OnInit {
   pageTitleDefault = 'Your New Trip';
   @Input() isEditing!: boolean;
   @Input() existingTrip!: Trip;
+
+  constructor(public nav: NavigationService) {}
 
   // updated from child component via @Output()
   // method for updating the page's title to match the user's title of their new trip

--- a/src/app/trips/trip-forms/trip-form/trip-form.component.ts
+++ b/src/app/trips/trip-forms/trip-form/trip-form.component.ts
@@ -24,6 +24,7 @@ import { NewTripComponent } from '../../.';
 import { AuthService, User, UserService } from 'src/app/user';
 import { UsernameValidator } from 'src/app/forms/validators/userExists.validator';
 import { Member } from 'src/app/shared/models/member.model';
+import { NavigationService } from 'src/app/shared';
 
 @Component({
   selector: 'app-trip-form',
@@ -69,7 +70,8 @@ export class TripFormComponent implements OnInit, OnDestroy {
     private tripService: TripService,
     private destinationsService: DestinationsService,
     private auth: AuthService,
-    private userService: UserService
+    private userService: UserService,
+    public nav: NavigationService
   ) {}
 
   ngOnInit() {
@@ -310,7 +312,7 @@ export class TripFormComponent implements OnInit, OnDestroy {
       // deactivate route guard
       this.tripComponent.isDirty = false;
       //reroute to newly created trip
-      this.router.navigate([`/trips/${addedTrip.id}`]);
+      this.nav.navigate([`/trips/${addedTrip.id}`]);
       this.destinationsService.clearAllDestinations();
     });
   }
@@ -322,7 +324,7 @@ export class TripFormComponent implements OnInit, OnDestroy {
       // deactivate route guard
       this.tripComponent.isDirty = false;
       //reroute to newly created trip
-      this.router.navigate([`/trips/${updatedTrip.id}`]);
+      this.nav.navigate([`/trips/${updatedTrip.id}`]);
       this.destinationsService.clearAllDestinations();
     });
   }

--- a/src/app/trips/trips-page/new-trip-thumbnail/new-trip-thumbnail.component.html
+++ b/src/app/trips/trips-page/new-trip-thumbnail/new-trip-thumbnail.component.html
@@ -1,4 +1,4 @@
-<div [routerLink]="['/trips/new']" class="thumbnail_box">
+<div (click)="nav.navigate(['/trips/new'])" class="thumbnail_box">
   <img src="assets/images/trips/newtrip1.jpg" alt="create new trip thumbnail" class="bg-img" />
   <div class="thumbnail_mask">
     <div class="plus-icon">

--- a/src/app/trips/trips-page/new-trip-thumbnail/new-trip-thumbnail.component.ts
+++ b/src/app/trips/trips-page/new-trip-thumbnail/new-trip-thumbnail.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { NavigationService } from 'src/app/shared';
 
 @Component({
   selector: 'app-new-trip-thumbnail',
@@ -8,4 +9,6 @@ import { Component, Input } from '@angular/core';
 export class NewTripThumbnailComponent {
   @Input() title = '';
   @Input() description = '';
+
+  constructor(public nav: NavigationService) {}
 }

--- a/src/app/trips/trips-page/trip-thumbnail/trip-thumbnail.component.html
+++ b/src/app/trips/trips-page/trip-thumbnail/trip-thumbnail.component.html
@@ -1,4 +1,4 @@
-<div [routerLink]="['/trips', trip.id]" class="thumbnail_box">
+<div (click)="nav.navigate(['/trips/', trip.id])" class="thumbnail_box">
   <!-- thumbnail image -->
   <img src="{{trip.imgURL}}" alt="{{trip.title}}" class="bg-img" />
 

--- a/src/app/trips/trips-page/trip-thumbnail/trip-thumbnail.component.ts
+++ b/src/app/trips/trips-page/trip-thumbnail/trip-thumbnail.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { Trip } from 'src/app/shared';
+import { Component, Input } from '@angular/core';
+import { Trip, NavigationService } from 'src/app/shared';
 import { TripService } from '../../shared/trip.service';
 
 @Component({
@@ -10,5 +10,5 @@ import { TripService } from '../../shared/trip.service';
 export class TripThumbnailComponent {
   @Input() trip!: Trip;
 
-  constructor(public tripService: TripService) {}
+  constructor(public tripService: TripService, public nav: NavigationService) {}
 }

--- a/src/app/trips/trips-page/trips-list/trips-list.component.html
+++ b/src/app/trips/trips-page/trips-list/trips-list.component.html
@@ -15,7 +15,7 @@
       <div class="collapse in row-fluid" id="{{upcomingCollapse}}">
 
         <!-- list of upcoming trip thumbnails (sorted to have soonest upcoming trips at the top)-->
-        <ng-container *ngFor="let trip of upcomingTrips | byEarliestDate">
+        <ng-container *ngFor="let trip of (upcomingTrips | byEarliestDate | async)">
           <div class="col-md-6 wrapper">
             <app-trip-thumbnail [trip]="trip"></app-trip-thumbnail>
           </div>
@@ -45,7 +45,7 @@
       <div class="collapse in row-fluid" id="{{previousCollapse}}">
 
         <!-- list of upcoming trip thumbnails (sorted to have most recent previous trips at the top)-->
-        <ng-container *ngFor="let trip of previousTrips | byLatestDate">
+        <ng-container *ngFor="let trip of (previousTrips | byLatestDate | async)">
           <div class="col-md-6 wrapper">
             <app-trip-thumbnail [trip]="trip"></app-trip-thumbnail>
           </div>

--- a/src/app/trips/trips-page/trips-list/trips-list.component.ts
+++ b/src/app/trips/trips-page/trips-list/trips-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Observable, of } from 'rxjs';
 import { Trip } from '../../../shared/models/trip.model';
 
 @Component({
@@ -8,8 +9,8 @@ import { Trip } from '../../../shared/models/trip.model';
 })
 export class TripsListComponent implements OnInit {
   currentTime = new Date();
-  upcomingTrips: Trip[] = [];
-  previousTrips: Trip[] = [];
+  upcomingTrips: Observable<Trip[]> = of([]);
+  previousTrips: Observable<Trip[]> = of([]);
 
   // displayed on new-trip-thumbnail
   // title and description for "create new trip" thumbnail in UPCOMING trip section
@@ -36,15 +37,15 @@ export class TripsListComponent implements OnInit {
 
   ngOnInit() {
     // get all upcoming trips
-    this.upcomingTrips = this.route.snapshot.data['trips'].filter(
+    this.upcomingTrips = of(this.route.snapshot.data['trips'].filter(
       (trip: Trip) =>
         new Date(trip.endDate).getTime() >= this.currentTime.getTime()
-    );
+    ));
 
     // get all previous trips
-    this.previousTrips = this.route.snapshot.data['trips'].filter(
+    this.previousTrips = of(this.route.snapshot.data['trips'].filter(
       (trip: Trip) =>
         new Date(trip.endDate).getTime() < this.currentTime.getTime()
-    );
+    ));
   }
 }

--- a/src/app/trips/trips-page/trips-title-section/trips-title-section.component.html
+++ b/src/app/trips/trips-page/trips-title-section/trips-title-section.component.html
@@ -15,7 +15,7 @@
   </h2>
 
   <div class="add-trip">
-    <a class="font700" [routerLink]="['/trips/new']"><span class="glyphicon glyphicon-plus"></span> Add Trip</a>
+    <a class="font700" (click)="nav.navigate(['/trips/new'])"><span class="glyphicon glyphicon-plus"></span> Add Trip</a>
   </div>
 
   <!-- sort: ADD FUNCITONALITY -->
@@ -28,7 +28,7 @@
     <ul class="dropdown-menu">
       <!-- sort by TITLE (A-Z) -->
       <li>
-        <a (click)="tripService.sortByTitle(tripList); sortToggle='sortByTitle';"
+        <a (click)="sortByTitle()"
           [ngClass]="{'sort-toggle': sortToggle==='sortByTitle'}">
           Title (A-Z)
         </a>
@@ -36,7 +36,7 @@
 
       <!-- sort by EARLIEST DATE (new-old) -->
       <li>
-        <a (click)="tripService.sortByEarliestDate(tripList); sortToggle='sortByEarliestDate';"
+        <a (click)="sortByEarliestDate()"
           [ngClass]="{'sort-toggle': sortToggle==='sortByEarliestDate'}">
           Earliest Date
         </a>
@@ -44,7 +44,7 @@
 
       <!-- sort by LATEST DATE (new-old) -->
       <li>
-        <a (click)="tripService.sortByLatestDate(tripList); sortToggle='sortByLatestDate';"
+        <a (click)="sortByLatestDate()"
           [ngClass]="{'sort-toggle': sortToggle==='sortByLatestDate'}">
           Latest Date
         </a>

--- a/src/app/trips/trips-page/trips-title-section/trips-title-section.component.ts
+++ b/src/app/trips/trips-page/trips-title-section/trips-title-section.component.ts
@@ -1,4 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, NgZone } from '@angular/core';
+import { Observable, of, take } from 'rxjs';
+import { NavigationService } from 'src/app/shared';
 import { Trip } from '../../../shared/models/trip.model';
 import { TripService } from '../../shared/trip.service';
 
@@ -10,8 +12,42 @@ import { TripService } from '../../shared/trip.service';
 export class TripsTitleSectionComponent {
   @Input() title = '';
   @Input() collapseID = '';
-  @Input() tripList: Trip[] = [];
+  @Input() tripList: Observable<Trip[]> = of();
   @Input() sortToggle = '';
 
-  constructor(public tripService: TripService) {}
+  constructor(
+    public tripService: TripService,
+    private ngZone: NgZone,
+    public nav: NavigationService
+  ) {}
+
+  sortByTitle() {
+    this.ngZone.run(() => {
+      this.tripService
+        .sortByTitle(this.tripList)
+        .pipe(take(1))
+        .subscribe((trips) => (this.tripList = of(trips)));
+      this.sortToggle = 'sortByTitle';
+    });
+  }
+
+  sortByEarliestDate() {
+    this.ngZone.run(() => {
+      this.tripService
+        .sortByEarliestDate(this.tripList)
+        .pipe(take(1))
+        .subscribe((trips) => (this.tripList = of(trips)));
+      this.sortToggle = 'sortByEarliestDate';
+    });
+  }
+
+  sortByLatestDate() {
+    this.ngZone.run(() => {
+      this.tripService
+        .sortByLatestDate(this.tripList)
+        .pipe(take(1))
+        .subscribe((trips) => (this.tripList = of(trips)));
+      this.sortToggle = 'sortByLatestDate';
+    });
+  }
 }


### PR DESCRIPTION
Things to note:
- When a user selects destinations via autocomplete while creating/updating a trip, Google placeIds are stored for each destination in the DB. The first destination of a trip is then used to grab a photo via Google Places API to automate trip images on the TravelTrack app. 
- According to Google's ToS, I'm unable to store the grabbed images in a DB and the URL generated on their end when requesting an image only lasts a day (so I can't store the Urls either). This means I had to implement it in such a way that requests are made upon viewing most 'trips/' related pages (which isn't how I wish I had to go about it as its less efficient and requests every time users access trip related pages)
- After adding the Google Place Details API requests, I was getting a NgZone warning (along with slow UI loading); I fixed this by implementing `NgZone.run()` for triggering change detection for routing when users want to navigate to '/trip' paths and sub-paths.

Implemented: 
- Google Places Details API for generating trip image for each trip
  - used to grab a photo of a place for each trip based on the first destination's id
  - assigns photo url to trip ImgURL
- Trip lists converted to observables
  - adjusted date pipes and trip list sorting methods
- Navigation Service (for trip paths)
  - wraps routing functions in `NgZone.run()` for entering Angular Zone